### PR TITLE
added the div tag inside the notification underscore template so that mc...

### DIFF
--- a/edx_notifications/server/web/templates/django/notifications_widget.html
+++ b/edx_notifications/server/web/templates/django/notifications_widget.html
@@ -28,14 +28,16 @@ page that is using this widget
 <script type="text/template" id="notification-pane-template">
     <div class="edx-notifications-container">
         <div class="edx-notifications-content">
-            <h2>Notifications</h2>
-            <div class="actions">
-                <ul class="notifications_list_tab">
-                    <li class="unread_notifications active"><a  href="#">View unread</a></li>
-                    <li class="user_notifications_all"><a href="#">View all</a></li>
-                    <li class="mark_notifications_read"><a href="#">Mark as read</a></li>
-                    <li class="hide_pane"><a href="#">Hide</a></li>
-                </ul>
+            <div class="fixed">
+                <h2>Notifications</h2>
+                <div class="actions">
+                    <ul class="notifications_list_tab">
+                        <li class="unread_notifications active"><a  href="#">View unread</a></li>
+                        <li class="user_notifications_all"><a href="#">View all</a></li>
+                        <li class="mark_notifications_read"><a href="#">Mark as read</a></li>
+                        <li class="hide_pane"><a href="#">Hide</a></li>
+                    </ul>
+                </div>
             </div>
             <ul>
                 <% if (typeof grouped_user_notifications == 'undefined' || grouped_user_notifications.length == 0) { %>


### PR DESCRIPTION
@chrisndodge I have added the div inside the notifications pane template. This need to be in the mcka:master, the css changes that we did in the mcka_repo depends on that div to be there so that they can load perfectly. Basically we have added a fixed div so that the user can scroll the notifications, the notifications tabs don't scroll, they will remain in the same position. only the notifications items will scroll down.

Thanks