### PR TITLE
Asadiqbal08/sol 512

### DIFF
--- a/edx_notifications/server/web/static/edx_notifications/js/views/notification_pane_view.js
+++ b/edx_notifications/server/web/static/edx_notifications/js/views/notification_pane_view.js
@@ -484,7 +484,7 @@ var NotificationPaneView = Backbone.View.extend({
                         if (clickLink && !$(e.target).hasClass("xns-close-item")) {
                             window.location.href = clickLink;
                         }
-                        else if ($(e.target).hasClass("xns-close-item")) {
+                        else if ($(e.target).hasClass("xns-close-item") && $(".xns-items li").length > 1) {
                             if(!($('#'+messageId).next().is( "li" )) && $('#'+messageId).prev().is( "h3" )){
                                 $('#'+messageId).prev().remove();
                             }

--- a/edx_notifications/server/web/static/edx_notifications/js/views/notification_pane_view.js
+++ b/edx_notifications/server/web/static/edx_notifications/js/views/notification_pane_view.js
@@ -481,8 +481,15 @@ var NotificationPaneView = Backbone.View.extend({
                     },
                     type: 'POST',
                     success: function () {
-                        if (clickLink) {
+                        if (clickLink && !$(e.target).hasClass("xns-close-item")) {
                             window.location.href = clickLink;
+                        }
+                        else if ($(e.target).hasClass("xns-close-item")) {
+                            if(!($('#'+messageId).next().is( "li" )) && $('#'+messageId).prev().is( "h3" )){
+                                $('#'+messageId).prev().remove();
+                            }
+                            $('#'+messageId).remove();
+                            self.counter_icon_view.refresh();
                         }
                         else {
                             self.unreadNotificationsClicked(e);

--- a/edx_notifications/server/web/templates/django/notifications_widget.html
+++ b/edx_notifications/server/web/templates/django/notifications_widget.html
@@ -64,7 +64,7 @@ page that is using this widget
                                         <span data-msg-id="<%= message.msg.id %>" data-click-link="<%=message.msg.payload['_click_link']%>" class='xns-<%= message.group_name %>'><%= message.html %></span>
                                     </div>
                                     <% if (selected_pane == 'unread') { %>
-                                          <div class="xns-close-item"><span class='xns-close-item-x'>x</span></div>
+                                          <div data-msg-id="<%= message.msg.id %>" class="xns-close-item"><span class='xns-close-item-x'>x</span></div>
                                     <% } %>
                                 </li>
                             <% }); %>

--- a/edx_notifications/server/web/templates/django/notifications_widget.html
+++ b/edx_notifications/server/web/templates/django/notifications_widget.html
@@ -64,7 +64,7 @@ page that is using this widget
                                         <span data-msg-id="<%= message.msg.id %>" data-click-link="<%=message.msg.payload['_click_link']%>" class='xns-<%= message.group_name %>'><%= message.html %></span>
                                     </div>
                                     <% if (selected_pane == 'unread') { %>
-                                          <div class="xns-close-item">x</div>
+                                          <div class="xns-close-item"><span class='xns-close-item-x'>x</span></div>
                                     <% } %>
                                 </li>
                             <% }); %>

--- a/edx_notifications/server/web/templates/django/notifications_widget.html
+++ b/edx_notifications/server/web/templates/django/notifications_widget.html
@@ -50,7 +50,7 @@ page that is using this widget
                         <% _.each(grouped_user_notifications, function(grouped_user_notification){ %>
                             <h3 class="xns-group"><%= grouped_user_notification.group_title %></h3>
                             <% _.each(grouped_user_notification.messages, function(message){ %>
-                                <li class="xns-item">
+                                <li class="xns-item" id="<%= message.msg.id %>">
                                     <% if (selected_pane == 'unread' && always_show_dates_on_unread) { %>
                                         <div class="xns-item-date">
                                             <% if (Date.equals(new Date(message.msg.created).clearTime(), Date.today())) { %>
@@ -63,6 +63,9 @@ page that is using this widget
                                     <div class="xns-item-body">
                                         <span data-msg-id="<%= message.msg.id %>" data-click-link="<%=message.msg.payload['_click_link']%>" class='xns-<%= message.group_name %>'><%= message.html %></span>
                                     </div>
+                                    <% if (selected_pane == 'unread') { %>
+                                          <div class="xns-close-item">x</div>
+                                    <% } %>
                                 </li>
                             <% }); %>
                         <% }); %>

--- a/testserver/static/css/styles.css
+++ b/testserver/static/css/styles.css
@@ -147,3 +147,33 @@ ul{
 	font-style: italic;
 	color: #888888;
 }
+.xns-item{
+    position: relative;
+}
+.xns-item-body{
+    padding: 5px;
+    position: relative;
+    width: 96%;
+}
+.xns-item:hover .xns-close-item{
+    display: block;
+}
+.xns-close-item {
+    background: none repeat scroll 0 0 #fff;
+    border: 1px solid #eee;
+    border-radius: 50%;
+    cursor: pointer;
+    display: none;
+    font-size: 11px;
+    font-weight: bold;
+    height: 16px;
+    position: absolute;
+    right: -7px;
+    text-align: center;
+    top: -7px;
+    width: 16px;
+    opacity: 0.8;
+}
+.xns-close-item:hover{
+    opacity: 1;
+}

--- a/testserver/test/acceptance/pages/logged_in_home_page.py
+++ b/testserver/test/acceptance/pages/logged_in_home_page.py
@@ -235,8 +235,8 @@ class LoggedInHomePage(PageObject):
             'close icon not found',
             timeout=default_timeout
         )
-        notification = self.browser.find_element_by_css_selector('.xns-items .xns-item-body>span')
-        icon = self.browser.find_element_by_css_selector(".xns-items .xns-close-item")
+        notification = self.browser.find_element_by_css_selector('.xns-items .xns-item-body')
+        icon = self.browser.find_element_by_css_selector(".xns-items .xns-close-item-x")
         action.move_to_element(notification).move_to_element(icon).click().perform()
         self.wait_for_element_presence(
             '.xns-content.unread .xns-empty-list',


### PR DESCRIPTION
@chrisndodge kindly review the change set. 

Changes are : 

- Added a sibling div element (class = "xns-close-item") to "xns-item-body"
- 'x' character  will appear on hover and only under the 'unread' pane/tab.
-  clicking on 'x' does not cause the user to lose scroll position.

1) notification has 'click_link' url: 
  - when a user will click on character 'x' , notification will be marked as read and removed from the pane. 
  - when a user will click on notification area instead of 'x' then notification will marked as read and redirected to the click_link url. (default behavior)

2) notification has NOT a 'click_link' URL : 
  - if user click on 'x' or anywhere on the notification then it will follow the same default behavior.

let me know if anything else is required in it. 

Thanks.
