### PR TITLE
rename publish_notification_to_scope() to bulk_publish_notification_to_s...

### DIFF
--- a/edx_notifications/lib/publisher.py
+++ b/edx_notifications/lib/publisher.py
@@ -168,7 +168,7 @@ def bulk_publish_notification_to_users(user_ids, msg, exclude_user_ids=None):
 
 
 @contract(msg=NotificationMessage)
-def publish_notification_to_scope(scope_name, scope_context, msg, exclude_user_ids=None):
+def bulk_publish_notification_to_scope(scope_name, scope_context, msg, exclude_user_ids=None):
     """
     This top level API method will publish a notification
     to a UserScope (potentially large). Basically this is a convenience method

--- a/edx_notifications/lib/tests/test_lib.py
+++ b/edx_notifications/lib/tests/test_lib.py
@@ -11,7 +11,7 @@ from edx_notifications.lib.publisher import (
     publish_notification_to_user,
     bulk_publish_notification_to_users,
     register_notification_type,
-    publish_notification_to_scope,
+    bulk_publish_notification_to_scope,
 )
 
 from edx_notifications.lib.consumer import (
@@ -326,7 +326,7 @@ class TestPublisherLibrary(TestCase):
             }
         )
 
-        publish_notification_to_scope(
+        bulk_publish_notification_to_scope(
             scope_name="list_scope",
             # the TestListScopeResolver expects a "range" property in the context
             scope_context={"range": 5},
@@ -357,7 +357,7 @@ class TestPublisherLibrary(TestCase):
         )
 
         with self.assertRaises(TypeError):
-            publish_notification_to_scope(
+            bulk_publish_notification_to_scope(
                 scope_name="bad-scope",
                 # the TestListScopeResolver expects a "range" property in the context
                 scope_context={"range": 5},


### PR DESCRIPTION
...cope() to keep naming more consistent