### PR TITLE
force purge Django Management command.

### DIFF
--- a/edx_notifications/management/commands/force_purge.py
+++ b/edx_notifications/management/commands/force_purge.py
@@ -1,0 +1,28 @@
+"""
+Django management command to force purge old notifications.
+To enable this feature, the following variables have to be defined in settings:
+NOTIFICATION_PURGE_READ_OLDER_THAN_DAYS
+NOTIFICATION_PURGE_UNREAD_OLDER_THAN_DAYS
+Optionally, the NOTIFICATION_ARCHIVE_ENABLED flag can be set to archive the purged notifications.
+"""
+
+import logging
+
+from django.core.management.base import BaseCommand
+from edx_notifications.lib.publisher import purge_expired_notifications
+
+log = logging.getLogger(__file__)
+
+
+class Command(BaseCommand):
+    """
+    Django Management command to force purge old notifications.
+    """
+
+    def handle(self, *args, **options):
+        """
+        Management command entry point, simply call into the signal firiing
+        """
+
+        log.info("Running management command to force purge old notifications...")
+        purge_expired_notifications()

--- a/edx_notifications/management/commands/tests/test_background_check.py
+++ b/edx_notifications/management/commands/tests/test_background_check.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from django.test import TestCase
 from django.dispatch import receiver
 
-from edx_notifications.management.commands import background_notification_check
+from edx_notifications.management.commands import background_notification_check, force_purge
 
 from edx_notifications.stores.store import notification_store
 from edx_notifications.background import (
@@ -67,3 +67,16 @@ class BackgroundCheckTest(TestCase):
 
         self.assertIsNotNone(readback_timer.executed_at)
         self.assertIsNone(readback_timer.err_msg)
+
+
+class PurgeNotificationsCommandTest(TestCase):
+    """
+    Test suite for the management command
+    """
+
+    def test_purge_command_check(self):
+        """
+        Invoke the Management Command
+        """
+
+        force_purge.Command().handle()

--- a/edx_notifications/management/commands/tests/test_background_check.py
+++ b/edx_notifications/management/commands/tests/test_background_check.py
@@ -2,6 +2,8 @@
 Run these tests @ Devstack:
     rake fasttest_lms[common/djangoapps/api_manager/management/commands/tests/test_migrate_orgdata.py]
 """
+from django.test.utils import override_settings
+from freezegun import freeze_time
 
 import pytz
 from datetime import datetime, timedelta
@@ -10,14 +12,15 @@ from django.test import TestCase
 from django.dispatch import receiver
 
 from edx_notifications.management.commands import background_notification_check, force_purge
+from edx_notifications.stores.sql.store_provider import SQLNotificationStoreProvider
 
 from edx_notifications.stores.store import notification_store
 from edx_notifications.background import (
     perform_notification_scan,
 )
 from edx_notifications.data import (
-    NotificationCallbackTimer
-)
+    NotificationCallbackTimer,
+    NotificationType, NotificationMessage, UserNotification)
 
 
 _SIGNAL_RAISED = False
@@ -74,9 +77,77 @@ class PurgeNotificationsCommandTest(TestCase):
     Test suite for the management command
     """
 
+    def setUp(self):
+        """
+        Setup the tests values.
+        """
+        self.provider = SQLNotificationStoreProvider()
+        self.test_user_id = 1
+        self.notification_type = NotificationType(
+            name='foo.bar.baz',
+            renderer='foo.renderer',
+            renderer_context={
+                'param1': 'value1'
+            },
+        )
+
     def test_purge_command_check(self):
         """
         Invoke the Management Command
         """
+        msg_type = self.provider.save_notification_type(self.notification_type)
+        msg1 = self.provider.save_notification_message(NotificationMessage(
+            namespace='namespace1',
+            msg_type=msg_type,
+            payload={
+                'foo': 'bar'
+            }
+        ))
 
+        msg2 = self.provider.save_notification_message(NotificationMessage(
+            namespace='namespace1',
+            msg_type=msg_type,
+            payload={
+                'test': 'test'
+            }
+        ))
+
+        # now reset the time to 66 days ago
+        # in order to save the user notification message in the past.
+        reset_time = datetime.now(pytz.UTC) - timedelta(days=66)
+        with freeze_time(reset_time):
+            self.provider.save_user_notification(UserNotification(
+                user_id=self.test_user_id,
+                msg=msg1
+            ))
+
+            self.provider.save_user_notification(UserNotification(
+                user_id=self.test_user_id,
+                msg=msg2
+            ))
+
+        # user notifications count
+        self.assertEqual(
+            self.provider.get_num_notifications_for_user(
+                self.test_user_id,
+                filters={
+                    'namespace': 'namespace1'
+                }
+            ),
+            2
+        )
+        # run the management command for purging notifications.
         force_purge.Command().handle()
+
+        # now get the user notification count.
+        # count should be 0 at that moment. because
+        # all the notifications have been deleted.
+        self.assertEqual(
+            self.provider.get_num_notifications_for_user(
+                self.test_user_id,
+                filters={
+                    'namespace': 'namespace1'
+                }
+            ),
+            0
+        )

--- a/edx_notifications/management/commands/tests/test_background_check.py
+++ b/edx_notifications/management/commands/tests/test_background_check.py
@@ -2,7 +2,6 @@
 Run these tests @ Devstack:
     rake fasttest_lms[common/djangoapps/api_manager/management/commands/tests/test_migrate_orgdata.py]
 """
-from django.test.utils import override_settings
 from freezegun import freeze_time
 
 import pytz


### PR DESCRIPTION
@chrisndodge, added the django management command to force-purge the notifications. : SOL-661