### PR TITLE
sol 764 Clicking outside of opened NotificationPane when user is on Settings tab, does not close the pane

### DIFF
--- a/edx_notifications/server/web/static/edx_notifications/js/views/notification_pane_view.js
+++ b/edx_notifications/server/web/static/edx_notifications/js/views/notification_pane_view.js
@@ -68,7 +68,7 @@ var NotificationPaneView = Backbone.View.extend({
         'click .xns-hide-pane': 'hidePane',
         'click .xns-item': 'visitNotification',
         'click .xns-close-item': 'closeNotification',
-        'click': 'preventHidingWhenClickedInside'
+        'click .xns-content': 'preventHidingWhenClickedInside'
     },
 
     template: null,


### PR DESCRIPTION
...er than the earlier "xns-container".