### PR TITLE
SOL-775 Notifications - "Mark as Read" tab becomes unresponsive

### DIFF
--- a/edx_notifications/server/web/static/edx_notifications/js/views/notification_pane_view.js
+++ b/edx_notifications/server/web/static/edx_notifications/js/views/notification_pane_view.js
@@ -427,7 +427,8 @@ var NotificationPaneView = Backbone.View.extend({
     },
     markNotificationsRead: function(e) {
         // this is only supported on the 'unread' view
-        if (this.selected_pane == 'unread' && this.collection.length > 0) {
+        if (this.selected_pane == 'unread' &&
+            (this.collection.url !== this.mark_all_read_endpoint || this.collection.length > 0)) {
             // set the API endpoint that was passed into our initializer
             this.collection.url = this.mark_all_read_endpoint;
 


### PR DESCRIPTION
Catered for a condition where the call to "mark all read" was being skipped since the collection had changed. Modified the check to enable the call to go through while still blocking multiple clicks on "Mark unread" from being passed to the server.