### PR TITLE
Update pytz to reflect upstream version change

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "gulp": "latest",
     "gulp-karma": "latest",
-    "karma": "latest",
+    "karma": ">=0.10 <=0.13",
     "karma-chrome-launcher": "latest",
     "karma-coverage": "latest",
     "karma-firefox-launcher": "latest",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ South>=0.7.6
 python-dateutil==2.1
 pylru==1.0.6
 djangorestframework>=2.3.5,<=2.3.14
-pytz==2012h
+pytz==2015.2
 PyContracts==1.6.5
 underscore.py==0.1.6
 pynliner==0.5.2


### PR DESCRIPTION
In certain circumstances the version of Pytz in this file will conflict with versions of pytz required by edx-platform in `requirements/edx/base.txt`. This PR makes the version in this repository match.