### PR TITLE
Registering GP v2 notification types

### DIFF
--- a/edx_notifications/openedx/group_project.py
+++ b/edx_notifications/openedx/group_project.py
@@ -12,6 +12,21 @@ from edx_notifications.renderers.basic import UnderscoreStaticFileRenderer
 
 from django.dispatch import receiver
 
+GROUP_PROJECT_V1_NOTIFICATION_PREFIX = u'open-edx.xblock.group-project'
+GROUP_PROJECT_V2_NOTIFICATION_PREFIX = u'open-edx.xblock.group-project-v2'
+
+GROUP_PROJECT_RENDERER_PREFIX = 'edx_notifications.openedx.group_project'
+
+
+class NotificationMessageTypes(object):
+    """
+    Message type constants
+    """
+    STAGE_OPEN = u'stage-open'
+    STAGE_DUE = u'stage-due'
+    FILE_UPLOADED = u'file-uploaded'
+    GRADES_POSTED = u'grades-posted'
+
 
 class GroupProjectFileUploadedRenderer(UnderscoreStaticFileRenderer):
     """
@@ -48,31 +63,25 @@ def register_notification_types(sender, **kwargs):  # pylint: disable=unused-arg
     This will be called automatically on the Notification subsystem startup (because we are
     receiving the 'perform_type_registrations' signal)
     """
+    mapping = {
+        NotificationMessageTypes.FILE_UPLOADED: 'GroupProjectFileUploadedRenderer',
+        NotificationMessageTypes.STAGE_OPEN: 'GroupProjectStageOpenRenderer',
+        NotificationMessageTypes.STAGE_DUE: 'GroupProjectStageDueRenderer',
+        NotificationMessageTypes.GRADES_POSTED: 'GroupProjectGradesPostedRenderer',
+    }
 
-    register_notification_type(
-        NotificationType(
-            name=u'open-edx.xblock.group-project.file-uploaded',
-            renderer='edx_notifications.openedx.group_project.GroupProjectFileUploadedRenderer',
+    for message_type, renderer in mapping.iteritems():
+        register_notification_type(
+            NotificationType(
+                name=u"{prefix}.{type}".format(prefix=GROUP_PROJECT_V1_NOTIFICATION_PREFIX, type=message_type),
+                renderer="{prefix}.{renderer}".format(prefix=GROUP_PROJECT_RENDERER_PREFIX, renderer=renderer),
+            )
         )
-    )
 
-    register_notification_type(
-        NotificationType(
-            name=u'open-edx.xblock.group-project.stage-open',
-            renderer='edx_notifications.openedx.group_project.GroupProjectStageOpenRenderer',
+        # GP v2 can reuse GP v1 renderers
+        register_notification_type(
+            NotificationType(
+                name=u"{prefix}.{type}".format(prefix=GROUP_PROJECT_V2_NOTIFICATION_PREFIX, type=message_type),
+                renderer="{prefix}.{renderer}".format(prefix=GROUP_PROJECT_RENDERER_PREFIX, renderer=renderer),
+            )
         )
-    )
-
-    register_notification_type(
-        NotificationType(
-            name=u'open-edx.xblock.group-project.stage-due',
-            renderer='edx_notifications.openedx.group_project.GroupProjectStageDueRenderer',
-        )
-    )
-
-    register_notification_type(
-        NotificationType(
-            name=u'open-edx.xblock.group-project.grades-posted',
-            renderer='edx_notifications.openedx.group_project.GroupProjectGradesPostedRenderer',
-        )
-    )


### PR DESCRIPTION
**Background:** Group Project XBlock sends notifications for file upload, grades posted and stage open/close dates. Group Project v2 sends the same types of messages, but uses different navigation approach, so the URLs in messages need to be different. For this to work, GP v2 has to send messages of unique types. 

**Description:** This PR registers new types of messages with notifications service.

**Dependencies:** This PR is one of the three that fix notifications in Group Project v2 XBlock; the other two are:
* https://github.com/edx-solutions/edx-platform/pull/517 - adds URLResolvers
* https://github.com/open-craft/xblock-group-project-v2/pull/53 - switches GP v2 to use dedicated message types

**Related:** [YONK-146](https://openedx.atlassian.net/browse/YONK-146) was caused by changing URL resolvers for GP v1. Should not be affected by this change.

**Testing instructions:** see testing instructions on https://github.com/edx-solutions/edx-platform/pull/517