### PR TITLE
Registered group project v2 in notification type mappings

### DIFF
--- a/edx_notifications/const.py
+++ b/edx_notifications/const.py
@@ -130,6 +130,7 @@ NOTIFICATION_DIGEST_GROUP_CONFIG = getattr(
             'open-edx.lms.leaderboard.*': 'leaderboards',
             'open-edx.studio.announcements.*': 'announcements',
             'open-edx.xblock.group-project.*': 'group_work',
+            'open-edx.xblock.group-project-v2.*': 'group_work',
             '*': '_default'
         },
     }

--- a/edx_notifications/server/web/static/edx_notifications/js/views/notification_pane_view.js
+++ b/edx_notifications/server/web/static/edx_notifications/js/views/notification_pane_view.js
@@ -209,6 +209,7 @@ var NotificationPaneView = Backbone.View.extend({
             'open-edx.lms.leaderboard.*': 'leaderboards',
             'open-edx.studio.announcements.*': 'announcements',
             'open-edx.xblock.group-project.*': 'group_work',
+            'open-edx.xblock.group-project-v2.*': 'group_work',
             '*': '_default'
         }
     },

--- a/testserver/test/acceptance/test_notifications.py
+++ b/testserver/test/acceptance/test_notifications.py
@@ -27,6 +27,10 @@ class TestAddNotifications(WebAppTest):
         'open-edx.xblock.group-project.stage-open': 'First Activity: Upload(s) are open',
         'open-edx.xblock.group-project.stage-due': 'First Activity: Upload(s) due 4/25',
         'open-edx.xblock.group-project.grades-posted': 'First Activity: Grade(s) are posted',
+        'open-edx.xblock.group-project-v2.file-uploaded': 'First Activity V2: testuser V2 uploaded a file',
+        'open-edx.xblock.group-project-v2.stage-open': 'First Activity V2: Upload(s) V2 are open',
+        'open-edx.xblock.group-project-v2.stage-due': 'First Activity V2: Upload(s) V2 due 4/25',
+        'open-edx.xblock.group-project-v2.grades-posted': 'First Activity V2: Grade(s) are posted',
     }
 
     short_notification_dict = {

--- a/testserver/views.py
+++ b/testserver/views.py
@@ -160,6 +160,31 @@ CANNED_TEST_PAYLOAD = {
         '_click_link': 'http://localhost:8000',
         'activity_name': 'First Activity',
     },
+    'open-edx.xblock.group-project-v2.file-uploaded': {
+        '_schema_version': 1,
+        '_click_link': 'http://localhost:8000',
+        'action_username': 'testuser V2',
+        'activity_name': 'First Activity V2',
+        'verb': 'uploaded a file',
+    },
+    'open-edx.xblock.group-project-v2.stage-open': {
+        '_schema_version': 1,
+        '_click_link': 'http://localhost:8000',
+        'activity_name': 'First Activity V2',
+        'stage': 'Upload(s) V2',
+    },
+    'open-edx.xblock.group-project-v2.stage-due': {
+        '_schema_version': 1,
+        '_click_link': 'http://localhost:8000',
+        'activity_name': 'First Activity V2',
+        'stage': 'Upload(s) V2',
+        'due_date': '4/25'
+    },
+    'open-edx.xblock.group-project-v2.grades-posted': {
+        '_schema_version': 1,
+        '_click_link': 'http://localhost:8000',
+        'activity_name': 'First Activity V2',
+    },
     'open-edx.lms.discussions.post-flagged': {
         '_schema_version': 1,
         '_click_link': 'http://localhost:8000',


### PR DESCRIPTION
**Description:** Follow up of #162 - group project v2 notifications were not added to notification type mappings back than, which caused [MCKIN-3659](https://edx-wiki.atlassian.net/browse/MCKIN-3659)

**JIRA:** [MCKIN-3659](https://edx-wiki.atlassian.net/browse/MCKIN-3659)

**Merge deadline:** Wednesday 10th EOD - fixes a bug in an active course, required for the next release.

**Installation instructions:** 
1. Since edx-notifications are installed as a dependency in another application (LMS or Apros), you'd need to update that application requirements file: `-e git+https://github.com/edx/edx-notifications.git@ce95728082ae3a0e89556c3e606b2a17210182b3#egg=edx-notifications
`
2. If edx-notifications client-side capabilities are used (i.e. for querying and displaying notifications), make sure `collectstatic` or equivalent command is issued - this PR contains JS changes

**Testing instructions:**
1. Generate any kind of GPv2 notification - the simplest is file upload notification (see https://github.com/edx-solutions/edx-platform/pull/517 for instructions)
2. Check notification "category" - it should be "Group Work", not "Other": 
![image](https://cloud.githubusercontent.com/assets/3330048/12919114/9c01cbaa-cf53-11e5-8772-7c7d463bcc4f.png)
