### PR TITLE
Add an OEP-2 compliant openedx.yaml file

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,0 +1,7 @@
+# This file describes this Open edX repo, as described in OEP-2:
+# http://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html#specification
+
+nick: ntf
+oeps: {}
+owner: MUST FILL IN OWNER
+track-pulls: true

--- a/openedx.yaml
+++ b/openedx.yaml
@@ -3,5 +3,5 @@
 
 nick: ntf
 oeps: {}
-owner: MUST FILL IN OWNER
+owner: edx/solutions-team
 track-pulls: true


### PR DESCRIPTION

This adds an `openedx.yaml` file, as described by OEP-2:
http://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html

The data in this file was transformed from the contents of
edx/repo-tools-data:repos.yaml
