### PR TITLE
pinned djangorestframework version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ django-model-utils==2.3.1
 python-dateutil==2.1
 requests==2.9.1
 pylru==1.0.6
-djangorestframework==3.2.3
+git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
 pytz==2016.7
 PyContracts==1.7.1
 underscore.py==0.1.6


### PR DESCRIPTION
This PR pinned djangorestframework version to get rid of this error
```
django.core.exceptions.AppRegistryNotReady: The translation infrastructure cannot be initialized before the apps registry is ready. Check that you don't make non-lazy gettext calls at import time.
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/manage.py", line 111, in <module>
    startup = importlib.import_module(edx_args.startup)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/edx/app/edxapp/edx-platform/lms/startup.py", line 21, in <module>
    import lms_xblock.runtime
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/lms_xblock/runtime.py", line 11, in <module>
    from openedx.core.djangoapps.user_api.course_tag import api as user_course_tag_api
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/user_api/course_tag/api.py", line 12, in <module>
    from ..models import UserCourseTag
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/user_api/models.py", line 18, in <module>
    from student.models import PendingEmailChange, Registration, UserProfile  # pylint: disable=unused-import
  File "/edx/app/edxapp/edx-platform/common/djangoapps/student/models.py", line 48, in <module>
    from certificates.models import GeneratedCertificate
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/certificates/models.py", line 70, in <module>
    from util.milestones_helpers import fulfill_course_milestone, is_prerequisite_courses_enabled
  File "/edx/app/edxapp/edx-platform/common/djangoapps/util/milestones_helpers.py", line 15, in <module>
    from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/__init__.py", line 5, in <module>
    import openedx.core.djangoapps.content.block_structure.signals
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/block_structure/signals.py", line 13, in <module>
    from .tasks import update_course_in_cache_v2
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/block_structure/tasks.py", line 11, in <module>
    from edxval.api import ValInternalError
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edxval/api.py", line 14, in <module>
    from edxval.serializers import VideoSerializer
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edxval/serializers.py", line 13, in <module>
    class EncodedVideoSerializer(serializers.ModelSerializer):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edxval/serializers.py", line 26, in EncodedVideoSerializer
    bitrate = IntegerField(min_value=0)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rest_framework/fields.py", line 823, in __init__
    message = self.error_messages['min_value'].format(min_value=self.min_value)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/functional.py", line 135, in __wrapper__
    res = func(*self.__args, **self.__kw)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/translation/__init__.py", line 84, in ugettext
    return _trans.ugettext(message)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/translation/trans_real.py", line 330, in ugettext
    return do_translate(message, 'ugettext')
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/translation/trans_real.py", line 307, in do_translate
    _default = _default or translation(settings.LANGUAGE_CODE)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/translation/trans_real.py", line 209, in translation
    _translations[language] = DjangoTranslation(language)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/translation/trans_real.py", line 118, in __init__
    self._add_installed_apps_translations()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/translation/trans_real.py", line 159, in _add_installed_apps_translations
    "The translation infrastructure cannot be initialized before the "
django.core.exceptions.AppRegistryNotReady: The translation infrastructure cannot be initialized before the apps registry is ready. Check that you don't make non-lazy gettext calls at import time.
```