### PR TITLE
fix visit notification non working link on Discussion page

### DIFF
--- a/edx_notifications/server/web/static/edx_notifications/js/views/notification_pane_view.js
+++ b/edx_notifications/server/web/static/edx_notifications/js/views/notification_pane_view.js
@@ -505,10 +505,11 @@ var NotificationPaneView = Backbone.View.extend({
             this.collection.url = this.mark_notification_read_endpoint + messageId;
 
             var self = this;
+            var csrf_token = this.getCSRFToken();
             self.collection.fetch(
                 {
-                    headers: {
-                        "X-CSRFToken": this.getCSRFToken()
+                    beforeSend: function(xhr) {
+                        xhr.setRequestHeader('X-CSRFToken', csrf_token);
                     },
                     data: {
                       "mark_as": "read"

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='edx-notifications',
-    version='0.7.6',
+    version='0.7.7',
     description='Notification subsystem for Open edX',
     long_description=open('README.md').read(),
     author='edX',


### PR DESCRIPTION
MCKIN-9970

On Notification page, Notification were not navigating to their associated links. It's a fix for this issue.

When we try to visit the notification, It send AJAX request to server to mark that specific notifictaion **read** while processing this request, it does not pass the **CSRF Token** in the request on **Discussion page**. This is a fix for it.