### PR TITLE
MCKIN-10378 - CSRF fix for mark as read

### DIFF
--- a/edx_notifications/server/web/static/edx_notifications/js/views/notification_pane_view.js
+++ b/edx_notifications/server/web/static/edx_notifications/js/views/notification_pane_view.js
@@ -463,8 +463,8 @@ var NotificationPaneView = Backbone.View.extend({
             }
             self.collection.fetch(
                 {
-                    headers: {
-                        "X-CSRFToken": this.getCSRFToken()
+                    beforeSend: function(xhr) {
+                        xhr.setRequestHeader('X-CSRFToken', self.getCSRFToken());
                     },
                     type: 'POST',
                     data: data,
@@ -539,8 +539,8 @@ var NotificationPaneView = Backbone.View.extend({
             var self = this;
             self.collection.fetch(
                 {
-                    headers: {
-                        "X-CSRFToken": this.getCSRFToken()
+                    beforeSend: function(xhr) {
+                        xhr.setRequestHeader('X-CSRFToken', self.getCSRFToken());
                     },
                     data: {
                       "mark_as": "read"

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='edx-notifications',
-    version='0.7.7',
+    version='0.7.8',
     description='Notification subsystem for Open edX',
     long_description=open('README.md').read(),
     author='edX',


### PR DESCRIPTION
This is the same fix as applied in #191 but was missed for other instances.

CSRF does not get passed when using `headers` now it is passed by beforeSend method of JQuery AJAX