### PR TITLE
remove js translations catalog loading script tag

### DIFF
--- a/edx_notifications/server/web/templates/django/notifications_widget_header.html
+++ b/edx_notifications/server/web/templates/django/notifications_widget_header.html
@@ -1,6 +1,5 @@
 {% load static %}
 {% load i18n %}
-<script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
 
 <script src="{% static 'edx_notifications/js/models/counter_icon_model.js' %}"></script>
 <script src="{% static 'edx_notifications/js/models/user_notification_model.js' %}"></script>

--- a/edx_notifications/server/web/templates/django/notifications_widget_header.html
+++ b/edx_notifications/server/web/templates/django/notifications_widget_header.html
@@ -4,7 +4,6 @@
 <script src="{% static 'edx_notifications/js/models/counter_icon_model.js' %}"></script>
 <script src="{% static 'edx_notifications/js/models/user_notification_model.js' %}"></script>
 <script src="{% static 'edx_notifications/js/collections/notification_collection.js' %}"></script>
-
 <script src="{% static 'edx_notifications/js/views/counter_icon_view.js' %}"></script>
 <script src="{% static 'edx_notifications/js/views/notification_pane_view.js' %}"></script>
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='edx-notifications',
-    version='0.7.8',
+    version='0.7.9',
     description='Notification subsystem for Open edX',
     long_description=open('README.md').read(),
     author='edX',

--- a/testserver/templates/index.html
+++ b/testserver/templates/index.html
@@ -8,6 +8,7 @@
     <script type="text/javascript" src="/static/js/underscore.js"></script>
     <script type="text/javascript" src="/static/js/backbone.js"></script>
     <script type="text/javascript" src="/static/js/date.js"></script>
+    <script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
 
 </head>
 <body>


### PR DESCRIPTION
Notifications widget should not load `javascript-catalog`, this is the responsibility of the template which is embedding this notification widget i-e the main layout template, having `javascript-catalog` in this widget template results in multiple inclusions of script tags referring to `javascript-catalog` URL in the dom.