### PR TITLE
MCKIN-11422 Upgrade pynliner to 0.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ pylru==1.0.6
 git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 PyContracts==1.7.1
 underscore.py==0.1.6
-pynliner==0.5.2
+pynliner==0.8.0
 git+https://github.com/milesrichardson/ParsePy.git


### PR DESCRIPTION
For upgrading python 2.7 to 3.5 on Apros, pynliner needs to be upgraded to 0.8.0 as it's compatible with python 3.5.

