### PR TITLE
Remove django_nose from prod settings

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -36,7 +36,6 @@ INSTALLED_APPS = (
     'rest_framework',
     'edx_notifications',
     'edx_notifications.server.web',
-    'django_nose',
 )
 
 REST_FRAMEWORK = {


### PR DESCRIPTION
It seems this isn't actually used in Prod and it's causing issues upgrading to python 3. Management commands try to import django_nose which doesn't exist and crashes.