### PR TITLE
Move freezegun to prod requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ PyContracts==1.7.1
 underscore.py==0.1.6
 pynliner==0.8.0
 git+https://github.com/milesrichardson/ParsePy.git
+freezegun>=0.1.11

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -13,5 +13,4 @@ bok-choy==0.6.2
 sure==1.2.3
 ddt==0.8.0
 selenium==2.53.1
-freezegun>=0.1.11
 tox==3.7.0


### PR DESCRIPTION
@ihtram we need this too. It's imported in edx_notifications/base_data.py which is used in prod.