### PR TITLE
MCKIN-12367: make notifications count context meaningful for screen readers

### DIFF
--- a/edx_notifications/server/web/templates/django/notifications_widget_header.html
+++ b/edx_notifications/server/web/templates/django/notifications_widget_header.html
@@ -12,6 +12,7 @@
 <script type="text/template" id="xns-counter-template">
     <% if (typeof count !== 'undefined' && count > 0) { %>
     <%= count %>
+    <span class="sr-only"> {% trans "unread" %}</span>
     <% } %>
 </script>
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='edx-notifications',
-    version='1.0.2',
+    version='1.0.3',
     description='Notification subsystem for Open edX',
     long_description=open('README.md').read(),
     author='edX',


### PR DESCRIPTION
[Issue]
The "Notifications" link in the header contains a number when there are unread notifications, but it will be rendered as "Notifications 3" to screen reader users, which does not clearly communicate the fact that three means 3 unread/new.

To fix this issue this PR adds `unread` text to clearly communicate to the screen readers.