### PR TITLE
[BD-6] Upgrade requirements and add python 3.8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 language: python
 
-matrix:
-  include:
-    - python: "3.5"
-      env: DJANGO_SETTINGS_MODULE=settings
-      script:
-        - tox -e py35
-        - ./node_modules/gulp/bin/gulp.js test
-        - bash ./run_bokchoy_tests.sh
+python:
+  - 3.5
+  - 3.8
+
+envs:
+  - TOXENV=django22
+  - TOXENV=quality
+
+script:
+  - tox
+  - ./node_modules/gulp/bin/gulp.js test
+  - bash ./run_bokchoy_tests.sh
 
 addons:
   firefox: "46.0"

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,8 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip install -q pip-tools
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --upgrade -o requirements/testing.txt requirements/testing.in
+	# Let tox control the Django version for tests
+	grep -e "^django==" requirements/base.txt > requirements/django.txt
+	sed -i.tmp '/^[dD]jango==/d' requirements/testing.txt
+	rm requirements/testing.txt.tmp
+

--- a/edx_notifications/base_data.py
+++ b/edx_notifications/base_data.py
@@ -47,10 +47,9 @@ class Dict(dict):
     Create a subclass of dict to make it weak referencable
     per https://docs.python.org/2/library/weakref.html
     """
-    pass
 
 
-class TypedField(object):
+class TypedField:
     """
     Field Decscriptors used to enforce correct typing
     """
@@ -417,7 +416,7 @@ class BaseDataObject(six.with_metaclass(BaseDataObjectMetaClass, object)):
         Validations should throw a ValidationError if there
         is a problem.
         """
-        pass  # this intentionally does nothing
+        # this intentionally does nothing
 
 
 class RelatedObjectField(TypedField):

--- a/edx_notifications/channels/link_resolvers.py
+++ b/edx_notifications/channels/link_resolvers.py
@@ -105,7 +105,7 @@ class MsgTypeToUrlLinkResolver(BaseLinkResolver):
             return None
 
 
-class MsgTypeToUrlResolverMixin(object):
+class MsgTypeToUrlResolverMixin:
     """
     Helper mix-in class to share logic when channels need to use
     similar link resolvers

--- a/edx_notifications/channels/tests/test_parse_push.py
+++ b/edx_notifications/channels/tests/test_parse_push.py
@@ -19,7 +19,7 @@ from edx_notifications.lib.publisher import register_notification_type
 from edx_notifications.channels.parse_push import _PARSE_SERVICE_USER_ID, ParsePushNotificationChannelProvider
 
 
-class MockCrashingParsePush(object):
+class MockCrashingParsePush:
     """
     Simulate an exception
     """

--- a/edx_notifications/lib/tests/test_lib.py
+++ b/edx_notifications/lib/tests/test_lib.py
@@ -254,7 +254,7 @@ class TestPublisherLibrary(TestCase):
 
         # now send to more than our internal chunking size
         bulk_publish_notification_to_users(
-            [user_id for user_id in range(1, const.NOTIFICATION_BULK_PUBLISH_CHUNK_SIZE * 2 + 1)],
+            list(range(1, const.NOTIFICATION_BULK_PUBLISH_CHUNK_SIZE * 2 + 1)),
             msg
         )
 
@@ -282,8 +282,8 @@ class TestPublisherLibrary(TestCase):
             }
         )
 
-        user_ids = [user_id for user_id in range(1, const.NOTIFICATION_BULK_PUBLISH_CHUNK_SIZE * 2 + 1)]
-        exclude_user_ids = [user_id for user_id in range(1, const.NOTIFICATION_BULK_PUBLISH_CHUNK_SIZE * 2 + 1, 2)]
+        user_ids = list(range(1, const.NOTIFICATION_BULK_PUBLISH_CHUNK_SIZE * 2 + 1))
+        exclude_user_ids = list(range(1, const.NOTIFICATION_BULK_PUBLISH_CHUNK_SIZE * 2 + 1, 2))
 
         # now send to more than our internal chunking size
         bulk_publish_notification_to_users(

--- a/edx_notifications/openedx/group_project.py
+++ b/edx_notifications/openedx/group_project.py
@@ -19,7 +19,7 @@ GROUP_PROJECT_V2_NOTIFICATION_PREFIX = u'open-edx.xblock.group-project-v2'
 GROUP_PROJECT_RENDERER_PREFIX = 'edx_notifications.openedx.group_project'
 
 
-class NotificationMessageTypes(object):
+class NotificationMessageTypes:
     """
     Message type constants
     """

--- a/edx_notifications/renderers/basic.py
+++ b/edx_notifications/renderers/basic.py
@@ -64,7 +64,7 @@ class UnderscoreStaticFileRenderer(BaseNotificationRenderer):
     underscore_template_name = None
     underscore_template = None
 
-    def __init__(self, template_name=None):
+    def __init__(self, template_name=None):  # pylint: disable=super-init-not-called
         """
         Initializer
         """

--- a/edx_notifications/scopes.py
+++ b/edx_notifications/scopes.py
@@ -31,7 +31,7 @@ class NotificationUserScopeResolver(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError()
 
 
-class SingleUserScopeResolver(object):
+class SingleUserScopeResolver:
     """
     Simple implementation for scope_name='user' where there must
     be a user_id inside the scope_context

--- a/edx_notifications/server/api/consumer.py
+++ b/edx_notifications/server/api/consumer.py
@@ -79,7 +79,7 @@ def _get_parameters_from_request(request, allowed_parameters):
                     raise ValueError(
                         "Passed in expected bool '{val}' does not map to True or False".format(val=str_val)
                     )
-            elif filter_type == str or filter_type == six.text_type:
+            elif filter_type in (str, six.text_type):
                 value = str_val
             else:
                 raise ValueError('Unknown parameter type {name}'.format(name=filter_type))

--- a/edx_notifications/stores/sql/models.py
+++ b/edx_notifications/stores/sql/models.py
@@ -35,7 +35,7 @@ class SQLNotificationType(models.Model):
     # any context to pass into the above renderer
     renderer_context = models.TextField(null=True)
 
-    class Meta(object):
+    class Meta:
         """
         ORM metadata about this class
         """
@@ -102,7 +102,7 @@ class SQLNotificationMessage(TimeStampedModel):
 
     object_id = models.CharField(max_length=255, db_index=True, null=True)
 
-    class Meta(object):
+    class Meta:
         """
         ORM metadata about this class
         """
@@ -177,7 +177,7 @@ class SQLUserNotificationArchive(TimeStampedModel):
 
     user_context = models.TextField(null=True)
 
-    class Meta(object):
+    class Meta:
         """
         ORM metadata about this class
         """
@@ -200,7 +200,7 @@ class SQLUserNotification(TimeStampedModel):
 
     user_context = models.TextField(null=True)
 
-    class Meta(object):
+    class Meta:
         """
         ORM metadata about this class
         """
@@ -251,7 +251,7 @@ class SQLNotificationChannel(models.Model):
     SMS, iOS Push Notifications, etc.
     """
 
-    class Meta(object):
+    class Meta:
         """
         ORM metadata about this class
         """
@@ -263,7 +263,7 @@ class SQLNotificationPreference(models.Model):
     """
     Notification preference
     """
-    class Meta(object):
+    class Meta:
         """
         ORM metadata about this class
         """
@@ -317,7 +317,7 @@ class SQLUserNotificationPreferences(TimeStampedModel):
     User specific mappings of Notifications to Channel, to reflect user preferences
     """
 
-    class Meta(object):
+    class Meta:
         """
         ORM metadata about this class
         """
@@ -367,7 +367,7 @@ class SQLNotificationCallbackTimer(TimeStampedModel):
     SQL implementation for NotificationCallbackTimer
     """
 
-    class Meta(object):
+    class Meta:
         """
         ORM metadata about this class
         """

--- a/edx_notifications/tests/test_scopes.py
+++ b/edx_notifications/tests/test_scopes.py
@@ -28,7 +28,7 @@ class TestListScopeResolver(NotificationUserScopeResolver):
         """
 
         if scope_name == 'list_scope':
-            return [num for num in range(scope_context['range'])]
+            return list(range(scope_context['range']))
 
         if scope_name == 'badtype_scope':
             return 1
@@ -71,7 +71,7 @@ class DjangoORMResolver(NotificationUserScopeResolver):
 
         if scope_name == 'values_list_query_set':
             return User.objects.values_list('id', flat=True).all()  # pylint: disable=no-member
-        elif scope_name == 'values_query_set':
+        if scope_name == 'values_query_set':
             return User.objects.values('id').all()  # pylint: disable=no-member
         return None
 
@@ -116,7 +116,7 @@ class ScopesTests(TestCase):
 
         self.assertIsNotNone(user_ids)
         self.assertEqual(len(user_ids), 5)
-        self.assertEqual(user_ids, [num for num in range(5)])
+        self.assertEqual(user_ids, list(range(5)))
 
         user_ids = resolve_user_scope('generator_scope', {'range': 10})
 
@@ -126,7 +126,7 @@ class ScopesTests(TestCase):
             compare.append(user_id)
 
         # generators dont support len()
-        self.assertEqual(compare, [num for num in range(10)])
+        self.assertEqual(compare, list(range(10)))
 
     def test_no_resolve(self):
         """
@@ -193,7 +193,7 @@ class ScopesTests(TestCase):
         """
 
         users = resolve_user_scope('values_list_query_set', {})
-        users_list = [user for user in users]
+        users_list = list(users)
         self.assertEqual(len(users_list), 1)
         self.assertEqual(users_list[0], self.test_user.id)
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,7 +1,7 @@
 # Django/Framework Packages
 django<2.3
 django-model-utils==2.3.1
-python-dateutil==2.1
+python-dateutil
 requests==2.22.0
 pylru==1.0.6
 djangorestframework==3.11.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,26 +4,26 @@
 #
 #    make upgrade
 #
-beautifulsoup4==4.8.2     # via pynliner
-certifi==2019.11.28       # via requests
+beautifulsoup4==4.9.0     # via pynliner
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
 cssutils==1.0.2           # via pynliner
-decorator==4.4.1          # via pycontracts
-django-model-utils==2.3.1  # via -r requirements/base.in (line 3)
-django==2.2.10            # via -r requirements/base.in (line 2), django-model-utils, djangorestframework
-djangorestframework==3.11.0  # via -r requirements/base.in (line 7)
-freezegun==0.3.12         # via -r requirements/base.in (line 12)
+decorator==4.4.2          # via pycontracts
+django-model-utils==2.3.1  # via -r requirements/base.in
+django==2.2.12            # via -r requirements/base.in, django-model-utils, djangorestframework
+djangorestframework==3.11.0  # via -r requirements/base.in
+freezegun==0.3.15         # via -r requirements/base.in
 idna==2.8                 # via requests
-git+https://github.com/milesrichardson/ParsePy.git  # via -r requirements/base.in (line 11)
-pycontracts==1.7.1        # via -r requirements/base.in (line 8)
-pylru==1.0.6              # via -r requirements/base.in (line 6)
-pynliner==0.8.0           # via -r requirements/base.in (line 10)
-pyparsing==2.4.6          # via pycontracts
-python-dateutil==2.1      # via -r requirements/base.in (line 4), freezegun
-pytz==2019.3              # via django
-requests==2.22.0          # via -r requirements/base.in (line 5)
+git+https://github.com/milesrichardson/ParsePy.git  # via -r requirements/base.in
+pycontracts==1.7.1        # via -r requirements/base.in
+pylru==1.0.6              # via -r requirements/base.in
+pynliner==0.8.0           # via -r requirements/base.in
+pyparsing==2.4.7          # via pycontracts
+python-dateutil==2.8.1    # via -r requirements/base.in, freezegun
+pytz==2020.1              # via django
+requests==2.22.0          # via -r requirements/base.in
 six==1.14.0               # via freezegun, parse-rest, python-dateutil
 soupsieve==2.0            # via beautifulsoup4
-sqlparse==0.3.0           # via django
-underscore.py==0.1.6      # via -r requirements/base.in (line 9)
-urllib3==1.25.8           # via requests
+sqlparse==0.3.1           # via django
+underscore.py==0.1.6      # via -r requirements/base.in
+urllib3==1.25.9           # via requests

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,0 +1,1 @@
+django==2.2.12            # via -r requirements/base.in, django-model-utils, djangorestframework

--- a/requirements/testing.in
+++ b/requirements/testing.in
@@ -1,18 +1,18 @@
 -r base.txt # Core dependencies for this package
 
 # Testing Packages
-coverage==4.0.2
-astroid==1.6.6
-django_nose==1.4.5
-nose==1.3.7
+coverage
+astroid
+django_nose
+nose
 httpretty==0.9.7
-pep8==1.5.7
-pylint==1.9.5
-pep257==0.3.2
+pycodestyle
+pylint
+pydocstyle
 mock==1.0.1
 testfixtures==4.5.0
 bok-choy==0.6.2
 sure==1.2.3
 ddt==0.8.0
 selenium==2.53.1
-tox==3.7.0
+tox

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -5,60 +5,59 @@
 #    make upgrade
 #
 appdirs==1.4.3            # via virtualenv
-astroid==1.6.6            # via -r requirements/testing.in (line 5), pylint
-beautifulsoup4==4.8.2     # via -r requirements/base.txt (line 7), pynliner
-bok-choy==0.6.2           # via -r requirements/testing.in (line 14)
-certifi==2019.11.28       # via -r requirements/base.txt (line 8), requests
-chardet==3.0.4            # via -r requirements/base.txt (line 9), requests
-coverage==4.0.2           # via -r requirements/testing.in (line 4)
-cssutils==1.0.2           # via -r requirements/base.txt (line 10), pynliner
-ddt==0.8.0                # via -r requirements/testing.in (line 16)
-decorator==4.4.1          # via -r requirements/base.txt (line 11), pycontracts
+astroid==2.4.1            # via -r requirements/testing.in, pylint
+beautifulsoup4==4.9.0     # via -r requirements/base.txt, pynliner
+bok-choy==0.6.2           # via -r requirements/testing.in
+certifi==2020.4.5.1       # via -r requirements/base.txt, requests
+chardet==3.0.4            # via -r requirements/base.txt, requests
+coverage==5.1             # via -r requirements/testing.in
+cssutils==1.0.2           # via -r requirements/base.txt, pynliner
+ddt==0.8.0                # via -r requirements/testing.in
+decorator==4.4.2          # via -r requirements/base.txt, pycontracts
 distlib==0.3.0            # via virtualenv
-django-model-utils==2.3.1  # via -r requirements/base.txt (line 12)
-django==2.2.10            # via -r requirements/base.txt (line 13), django-model-utils, djangorestframework
-django_nose==1.4.5        # via -r requirements/testing.in (line 6)
-djangorestframework==3.11.0  # via -r requirements/base.txt (line 14)
+django-model-utils==2.3.1  # via -r requirements/base.txt
+django-nose==1.4.6        # via -r requirements/testing.in
+djangorestframework==3.11.0  # via -r requirements/base.txt
 filelock==3.0.12          # via tox, virtualenv
-freezegun==0.3.12         # via -r requirements/base.txt (line 15)
-httpretty==0.9.7          # via -r requirements/testing.in (line 8)
-idna==2.8                 # via -r requirements/base.txt (line 16), requests
-importlib-metadata==1.5.0  # via pluggy, virtualenv
-importlib-resources==1.0.2  # via virtualenv
+freezegun==0.3.15         # via -r requirements/base.txt
+httpretty==0.9.7          # via -r requirements/testing.in
+idna==2.8                 # via -r requirements/base.txt, requests
+importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
+importlib-resources==1.5.0  # via virtualenv
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
 lazy==1.4                 # via bok-choy
 mccabe==0.6.1             # via pylint
-mock==1.0.1               # via -r requirements/testing.in (line 12)
+mock==1.0.1               # via -r requirements/testing.in
 needle==0.5.0             # via bok-choy
-nose==1.3.7               # via -r requirements/testing.in (line 7), django-nose, needle
-git+https://github.com/milesrichardson/ParsePy.git  # via -r requirements/base.txt (line 17)
-pep257==0.3.2             # via -r requirements/testing.in (line 11)
-pep8==1.5.7               # via -r requirements/testing.in (line 9)
-pillow==7.0.0             # via needle
+nose==1.3.7               # via -r requirements/testing.in, django-nose, needle
+packaging==20.3           # via tox
+git+https://github.com/milesrichardson/ParsePy.git  # via -r requirements/base.txt
+pillow==7.1.2             # via needle
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
-pycontracts==1.7.1        # via -r requirements/base.txt (line 18)
-pylint==1.9.5             # via -r requirements/testing.in (line 10)
-pylru==1.0.6              # via -r requirements/base.txt (line 19)
-pynliner==0.8.0           # via -r requirements/base.txt (line 20)
-pyparsing==2.4.6          # via -r requirements/base.txt (line 21), pycontracts
-python-dateutil==2.1      # via -r requirements/base.txt (line 22), freezegun
-pytz==2019.3              # via -r requirements/base.txt (line 23), django
-requests==2.22.0          # via -r requirements/base.txt (line 24)
-selenium==2.53.1          # via -r requirements/testing.in (line 17), bok-choy, needle
-six==1.14.0               # via -r requirements/base.txt (line 25), astroid, bok-choy, freezegun, httpretty, parse-rest, pylint, python-dateutil, tox, virtualenv
-soupsieve==2.0            # via -r requirements/base.txt (line 26), beautifulsoup4
-sqlparse==0.3.0           # via -r requirements/base.txt (line 27), django
-sure==1.2.3               # via -r requirements/testing.in (line 15)
-testfixtures==4.5.0       # via -r requirements/testing.in (line 13)
-toml==0.10.0              # via tox
-tox==3.7.0                # via -r requirements/testing.in (line 18)
-underscore.py==0.1.6      # via -r requirements/base.txt (line 28)
-urllib3==1.25.8           # via -r requirements/base.txt (line 29), requests
-virtualenv==20.0.5        # via tox
-wrapt==1.12.0             # via astroid
-zipp==1.2.0               # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools
+pycodestyle==2.5.0        # via -r requirements/testing.in
+pycontracts==1.7.1        # via -r requirements/base.txt
+pydocstyle==5.0.2         # via -r requirements/testing.in
+pylint==2.5.2             # via -r requirements/testing.in
+pylru==1.0.6              # via -r requirements/base.txt
+pynliner==0.8.0           # via -r requirements/base.txt
+pyparsing==2.4.7          # via -r requirements/base.txt, packaging, pycontracts
+python-dateutil==2.8.1    # via -r requirements/base.txt, freezegun
+pytz==2020.1              # via -r requirements/base.txt, django
+requests==2.22.0          # via -r requirements/base.txt
+selenium==2.53.1          # via -r requirements/testing.in, bok-choy, needle
+six==1.14.0               # via -r requirements/base.txt, astroid, bok-choy, freezegun, httpretty, packaging, parse-rest, python-dateutil, tox, virtualenv
+snowballstemmer==2.0.0    # via pydocstyle
+soupsieve==2.0            # via -r requirements/base.txt, beautifulsoup4
+sqlparse==0.3.1           # via -r requirements/base.txt, django
+sure==1.2.3               # via -r requirements/testing.in
+testfixtures==4.5.0       # via -r requirements/testing.in
+toml==0.10.0              # via pylint, tox
+tox==3.15.0               # via -r requirements/testing.in
+typed-ast==1.4.1          # via astroid
+underscore.py==0.1.6      # via -r requirements/base.txt
+urllib3==1.25.9           # via -r requirements/base.txt, requests
+virtualenv==20.0.20       # via tox
+wrapt==1.12.1             # via astroid
+zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
-[pep8]
-ignore=E501
+[pycodestyle]
+ignore=E501,W504
 max_line_length=119
 exclude=settings,*/migrations/*,edx_notifications/server/envs/*
 [isort]

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='edx-notifications',
-    version='1.1.0',
+    version='1.2.0',
     description='Notification subsystem for Open edX',
     long_description=open('README.md').read(),
     author='edX',
@@ -52,12 +52,9 @@ setup(
         'Operating System :: OS Independent',
         'Framework :: Django',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     packages=['edx_notifications'],
     dependency_links=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-django111, py35-django111
+envlist = py35-django22,py38-django{22,30},quality
 
 [testenv]
 deps =
@@ -11,5 +11,8 @@ commands =
     coverage run manage.py test edx_notifications --verbosity=3
     coverage report -m
     coverage html
-    pep8 edx_notifications
+
+[textenv:quality]
+commands =
+    pycodestyle edx_notifications
     pylint edx_notifications --reports=no


### PR DESCRIPTION
## Description:

Upgrade requirements.
Add python 3.8 tests
Remove python 2.7 from tox,
Change tox.ini to add capability to run tests with django 3.0

## Reviewers
- [ ] @awais786 
- [ ] @ericfab179